### PR TITLE
Filter list when updating data and panel is open

### DIFF
--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -223,6 +223,10 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
 
     this.filteredList = this.data;
     this.notFound = !this.filteredList || this.filteredList.length === 0;
+    
+    if (this.isOpen) {
+      this.filterList();
+    }
   }
 
   /**


### PR DESCRIPTION
While it is currently possible to update component data on the fly, if a search is underway, the filtered list is set as the new data, and then not filtered. This checks to see if the panel is open and then applies the filters accordingly.