### PR TITLE
feature: Auto select first

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ class TestComponent {
 | minQueryLength | `number` | `1` | no | The minimum number of characters the user must type before a search is performed. |
 | debounceTime | `number` | `400` | no | Delay time while typing. |
 | disabled | `boolean` | `false` | no | input disable/enable. |
+| autoSelectFirst | `boolean` | `false` | no | Automatically select the first matched option on the list |
 
 ### Outputs
 | Output  | Description |

--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -101,6 +101,10 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
    * The minimum number of characters the user must type before a search is performed.
    */
   @Input() public minQueryLength = 1;
+  /**
+   * Auto selects the first option found
+   */
+  @Input() public autoSelectFirst = false;
 
 
   // @Output events
@@ -242,6 +246,9 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
           return item[this.searchKeyword].toLowerCase().indexOf(this.query.toLowerCase()) > -1;
         }
       });
+      if (this.filteredList.length > 0 && this.autoSelectFirst) {
+        this.selectedIdx = 0;
+      }
     } else {
       this.notFound = false;
     }


### PR DESCRIPTION
Setting `[autoSelectFirst]="true"` on the main component will automatically select the first matched option on the list, allowing the user to press enter to select immediately