### PR TITLE
Fixed blur event not changing the control touched status using ReactiveForms

### DIFF
--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.html
@@ -5,6 +5,7 @@
            [(ngModel)]=query
            (input)="onChange($event)"
            (focus)=handleFocus($event)
+           (blur)=onTouched($event)
            [disabled]="disabled">
     <div class="x" *ngIf="query && !isLoading && !disabled" (click)="remove($event)">
       <i class="material-icons">close</i>

--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -137,6 +137,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
   propagateChange: any = () => {
   };
 
+  onTouched: any = () => {};
 
   /**
    * Writes a new value from the form model into the view,
@@ -156,7 +157,8 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
   /**
    * Registers a handler specifically for when a control receives a touch event
    */
-  registerOnTouched(fn: () => void): void {
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
   }
 
   /**


### PR DESCRIPTION
Fixed the touched status not being updated after the user leaves the input

The touched status was not being updated:

<img src="https://user-images.githubusercontent.com/36421128/90571492-d773ad00-e17f-11ea-8ef4-8b80befdd017.png" width="40%" heigth="40%">