### PR TITLE
Event not defined error in older browsers like firefox 47

### DIFF
--- a/projects/autocomplete-lib/package.json
+++ b/projects/autocomplete-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ng-autocomplete",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Angular autocomplete",
   "keywords": [
     "angular",

--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -513,7 +513,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
     this.inputFocused.emit(e);
     // if data exists then open
     if (this.data && this.data.length) {
-      this.setPanelState(event);
+      this.setPanelState(e);
     }
     this.isFocused = true;
   }


### PR DESCRIPTION
#### Changes
Removed event var that was not defined.
Changed event variable to 'e' variable, I beleave that it was a typo.
I fix this because it causing error in older browsers like firefox 47 when focused input.
Because this the popup with list results not listing at focus.

Fixes # (issue)
Varible event not defined

#### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
