### PR TITLE
Custom function to render selected value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ class TestComponent {
 | [data] | `Array<any>`  | `null` | yes | Items array. It can be array of strings or array of objects. |
 | searchKeyword | `string` |  `-` | yes | Variable name to filter data with. |
 | customFilter | `(items: any[], query: string) => any[]` | `undefined` | no | Custom filter function. You can use it to provide your own filtering function, as e.g. fuzzy-matching filtering, or to disable filtering at all (just pass `(items) => items` as a filter). Do not change the `items` argument given, return filtered list instead. |
+| selectedValueRender | `(value: any) => string` | `undefined` | no | Custom renderer function to render selected value inside input field |
 | placeholder  | `string` | `-` | no |  HTML `<input>` placeholder text.  |
 | heading | `string` | `-` | no | Heading text of items list. If it is null then heading is hidden. |
 | initialValue | `any` | `_` | no | initial/default selected value. |

--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -112,6 +112,12 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
    */
   @Input() public customFilter: (items: any[], query: string) => any[];
 
+  /**
+   * Custom result render function
+   * @param value - selected value to be rendered inside input field
+   */
+  @Input() public selectedValueRender: (value: any) => string;
+
   // @Output events
   /** Event that is emitted whenever an item from the list is selected. */
   @Output() selected = new EventEmitter<any>();
@@ -154,7 +160,11 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
    * Updates model
    */
   writeValue(value: any = '') {
-    this.query = value && !this.isTypeString(value) ? value[this.searchKeyword] : value;
+    this.query = this.selectedValueRender !== undefined ? this.selectedValueRender(value) : this.defaultWriteValue(value);
+  }
+
+  private defaultWriteValue(value: any) {
+    return value && !this.isTypeString(value) ? value[this.searchKeyword] : value;
   }
 
   /**


### PR DESCRIPTION
#### Changes
As for now objects are rendered only by property `searchKeyword` which is not very flexible. There are lot of cases when two and more properties of selected object should be used to render selected result.

This PR introduce new input function - `selectedValueRender`. This function will accept selected object and render final result

#### Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
