### PR TITLE
searchKeyword can be null

### DIFF
--- a/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/autocomplete-lib/src/lib/autocomplete/autocomplete.component.ts
@@ -270,7 +270,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, AfterViewInit, 
         return item.toLowerCase().indexOf(this.query.toLowerCase()) > -1;
       } else if (typeof item === 'object' && item instanceof Object) {
         // object logic, check property equality
-        return item[this.searchKeyword].toLowerCase().indexOf(this.query.toLowerCase()) > -1;
+        return item[this.searchKeyword] ? item[this.searchKeyword].toLowerCase().indexOf(this.query.toLowerCase()) > -1 : "";
       }
     });
   }


### PR DESCRIPTION
#### Changes
when searchKeyword is null, toLowerCase() does not work and autocomplete does not show anything.
by this fix if it is null, script is continuing to work

Fixes # (issue)

#### Type of change
<!-- Please delete options that are not relevant. -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
